### PR TITLE
change keyname without prefix

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -3,7 +3,9 @@ import Config
 config :giocci_relay_zenoh, :system_variables,
   my_node_name: "relay1",
   engine_node_name: ["engine1", "engine2", "engine3", "engine4", "engine5"],
-  client_node_name: "client1"
+  client_node_name: "client1",
+  client_name_tosend: "client1",
+  engine_name_tosend: "engine1"
 
 config :giocci_relay, :system_variables,
   node_name: "relay",

--- a/lib/giocci_relay_zenoh.ex
+++ b/lib/giocci_relay_zenoh.ex
@@ -14,6 +14,79 @@ defmodule GiocciRelayZenoh do
     最初に指定された数のEngineノードとのZenohコネクションを作成する（clientは一個想定
   """
   def setup_relay() do
+    relay_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:my_node_name]
+    client_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:client_node_name]
+    ## RelayのZenohセッションを起動
+    {:ok, session} = Zenohex.open()
+    ## pub,subそれぞれのキーをたてる
+
+    {:ok, subscriber} =
+      Zenohex.Session.declare_subscriber(
+        session,
+        "key_prefix/giocci/client_to_relay/" <> relay_name
+      )
+
+    id_string = relay_name <> "sub from client"
+    ## 状態として次の状態をもつ
+    state = %{
+      subscriber_client2relay: subscriber,
+      callback_client2relay: &callback_fromclient/2,
+      id: String.to_atom(id_string),
+      session: session
+    }
+
+    ## 上記の状態を保存する用のGenServerの起動
+    GenServer.start_link(__MODULE__, state, name: String.to_atom(id_string))
+    Logger.info("key_prefix/giocci/client_to_relay/" <> relay_name)
+    ## subの開始
+    subscriber_loop_client2relay(state)
+    {:ok, state}
+
+    {:ok, session} = Zenohex.open()
+    ## pub,subそれぞれのキーをたてる
+
+    {:ok, publisher} =
+      Zenohex.Session.declare_publisher(
+        session,
+        "key_prefix/giocci/relay_to_client/" <> client_name
+      )
+
+    id_string = client_name <> relay_name <> "pub"
+    ## 状態として次の状態をもつ
+    state = %{
+      publisher_relay2client: publisher,
+      id: String.to_atom(id_string),
+      session: session
+    }
+
+    ## 上記の状態を保存する用のGenServerの起動
+    GenServer.start_link(__MODULE__, state, name: String.to_atom(id_string))
+    ## subの開始
+    {:ok, state}
+
+    {:ok, session} = Zenohex.open()
+    ## subのキーをたてる
+    {:ok, subscriber} =
+      Zenohex.Session.declare_subscriber(
+        session,
+        "key_prefix/giocci/engine_to_relay/" <> relay_name
+      )
+
+    id_string = relay_name <> "sub from engine"
+    ## 状態として次の状態をもつ
+    state = %{
+      subscriber_engine2relay: subscriber,
+      callback_engine2relay: &callback_fromengine/2,
+      id: String.to_atom(id_string),
+      session: session
+    }
+
+    ## 上記の状態を保存する用のGenServerの起動
+    GenServer.start_link(__MODULE__, state, name: String.to_atom(id_string))
+    ## subの開始
+    subscriber_loop_engine2relay(state)
+    {:ok, state}
+
     create_session(Application.get_env(:giocci_relay_zenoh, :system_variables)[:engine_node_name])
   end
 
@@ -22,38 +95,26 @@ defmodule GiocciRelayZenoh do
     client_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:client_node_name]
     ## RelayのZenohセッションを起動
     {:ok, session} = Zenohex.open()
-    ## pub,subそれぞれのキーをたてる
-    {:ok, subscriber1} =
-      Zenohex.Session.declare_subscriber(session, "from/" <> engine_name <> "/to/" <> relay_name)
+    ## pubキーをたてる
 
-    {:ok, publisher1} =
-      Zenohex.Session.declare_publisher(session, "from/" <> relay_name <> "/to/" <> client_name)
+    {:ok, publisher} =
+      Zenohex.Session.declare_publisher(
+        session,
+        "key_prefix/giocci/relay_to_engine/" <> engine_name
+      )
 
-    {:ok, subscriber2} =
-      Zenohex.Session.declare_subscriber(session, "from/" <> client_name <> "/to/" <> relay_name)
-
-    {:ok, publisher2} =
-      Zenohex.Session.declare_publisher(session, "from/" <> relay_name <> "/to/" <> engine_name)
-
-    id_string = client_name <> engine_name
+    id_string = relay_name <> engine_name <> "pub"
     ## 状態として次の状態をもつ
     state = %{
-      publisher_relay2client: publisher1,
-      subscriber_engine2relay: subscriber1,
-      callback_engine2relay: &callback_fromengine/2,
-      publisher_relay2engine: publisher2,
-      subscriber_client2relay: subscriber2,
-      callback_client2relay: &callback_fromclient/2,
+      publisher_relay2engine: publisher,
       id: String.to_atom(id_string),
       session: session
     }
 
     ## 上記の状態を保存する用のGenServerの起動
     GenServer.start_link(__MODULE__, state, name: String.to_atom(id_string))
-    Logger.info("from/" <> relay_name <> "/to/" <> engine_name)
+    Logger.info("key_prefix/giocci/relay_to_engine/" <> engine_name)
     ## subの開始
-    subscriber_loop_engine2relay(state)
-    subscriber_loop_client2relay(state)
     {:ok, state}
   end
 
@@ -66,6 +127,7 @@ defmodule GiocciRelayZenoh do
       reference: reference
     } = message
 
+    relay_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:my_node_name]
     ## msgをバイナリからlistにもどす
     message_readable =
       message_intermediate
@@ -76,11 +138,27 @@ defmodule GiocciRelayZenoh do
     case message_readable do
       ## module_execの場合
       [_, _, _, :module_exec] = message_readable ->
-        Zenohex.Publisher.put(state.publisher_relay2engine, message_intermediate)
+        engine_name_tosend =
+          Application.get_env(:giocci_relay_zenoh, :system_variables)[:engine_name_tosend]
+
+        id = (relay_name <> engine_name_tosend <> "pub") |> String.to_atom()
+        ## publisherをセッションから作成しpublishする
+        [publisher] =
+          GenServer.call(id, :call_publisher_toengine)
+
+        Zenohex.Publisher.put(publisher, message_intermediate)
 
       ## module_saveの場合
       [_, :module_save] = message_readable ->
-        Zenohex.Publisher.put(state.publisher_relay2engine, message_intermediate)
+        engine_name_tosend =
+          Application.get_env(:giocci_relay_zenoh, :system_variables)[:engine_name_tosend]
+
+        id = (relay_name <> engine_name_tosend <> "pub") |> String.to_atom()
+        ## publisherをセッションから作成しpublishする
+        [publisher] =
+          GenServer.call(id, :call_publisher_toengine)
+
+        Zenohex.Publisher.put(publisher, message_intermediate)
 
       _ = message_readable ->
         Logger.error(inspect("no match"))
@@ -96,7 +174,27 @@ defmodule GiocciRelayZenoh do
       reference: reference
     } = message
 
-    Zenohex.Publisher.put(state.publisher_relay2client, message_intermediate)
+    relay_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:my_node_name]
+
+    client_name_tosend =
+      Application.get_env(:giocci_relay_zenoh, :system_variables)[:client_name_tosend]
+
+    id = (client_name_tosend <> relay_name <> "pub") |> String.to_atom()
+    ## publisherをセッションから作成しpublishする
+    [publisher] =
+      GenServer.call(id, :call_publisher_toclient)
+
+    Zenohex.Publisher.put(publisher, message_intermediate)
+  end
+
+  def handle_call(:call_publisher_toengine, _from, state) do
+    reply = [state.publisher_relay2engine]
+    {:reply, reply, state}
+  end
+
+  def handle_call(:call_publisher_toclient, _from, state) do
+    reply = [state.publisher_relay2client]
+    {:reply, reply, state}
   end
 
   ##   subをループするhandle info

--- a/lib/giocci_relay_zenoh.ex
+++ b/lib/giocci_relay_zenoh.ex
@@ -42,9 +42,9 @@ defmodule GiocciRelayZenoh do
     id_string = relay_name <> engine_name
     ## 状態として次の状態をもつ
     state = %{
-      publisher_relay2engine: publisher,
-      subscriber_engine2relay: subscriber,
-      callback_engine2relay: &callback_fromengine/2,
+      publisher_relay_to_engine: publisher,
+      subscriber_engine_to_relay: subscriber,
+      callback_engine_to_relay: &callback_from_engine/2,
       id: String.to_atom(id_string),
       session: session
     }
@@ -53,7 +53,7 @@ defmodule GiocciRelayZenoh do
     GenServer.start_link(__MODULE__, state, name: String.to_atom(id_string))
     Logger.info("key_prefix/giocci/relay_to_engine/" <> relay_name <> "/" <> engine_name)
     ## subの開始
-    subscriber_loop_engine2relay(state)
+    subscriber_loop_engine_to_relay(state)
     {:ok, state}
   end
 
@@ -62,7 +62,7 @@ defmodule GiocciRelayZenoh do
   end
 
   ## Clientから送られたデータを解析して、やりたい動作ごとに割り振るコールバック関数
-  def callback_fromclient(state, message) do
+  def callback_from_client(_state, message) do
     message_value = Map.get(message, :value)
     relay_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:my_node_name]
 
@@ -102,7 +102,7 @@ defmodule GiocciRelayZenoh do
   end
 
   ## Engineから送られたメッセージを抽出し、Clientに返送
-  def callback_fromengine(state, message) do
+  def callback_from_engine(_state, message) do
     message_value = Map.get(message, :value)
 
     relay_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:my_node_name]
@@ -118,24 +118,24 @@ defmodule GiocciRelayZenoh do
   end
 
   def handle_call(:call_publisher_toengine, _from, state) do
-    reply = [state.publisher_relay2engine]
+    reply = [state.publisher_relay_to_engine]
     {:reply, reply, state}
   end
 
   def handle_call(:call_publisher_toclient, _from, state) do
-    reply = [state.publisher_relay2client]
+    reply = [state.publisher_relay_to_client]
     {:reply, reply, state}
   end
 
   ##   subをループするhandle info
-  def handle_info(:loop_engine2relay, state) do
-    subscriber_loop_engine2relay(state)
+  def handle_info(:loop_engine_to_relay, state) do
+    subscriber_loop_engine_to_relay(state)
     {:noreply, state}
   end
 
   ##   subをループするhandle info
-  def handle_info(:loop_client2relay, state) do
-    subscriber_loop_client2relay(state)
+  def handle_info(:loop_client_to_relay, state) do
+    subscriber_loop_client_to_relay(state)
     {:noreply, state}
   end
 
@@ -161,9 +161,9 @@ defmodule GiocciRelayZenoh do
     id_string = client_name <> relay_name
     ## 状態として次の状態をもつ
     state = %{
-      subscriber_client2relay: subscriber,
-      publisher_relay2client: publisher,
-      callback_client2relay: &callback_fromclient/2,
+      subscriber_client_to_relay: subscriber,
+      publisher_relay_to_client: publisher,
+      callback_client_to_relay: &callback_from_client/2,
       id: String.to_atom(id_string),
       session: session
     }
@@ -172,7 +172,7 @@ defmodule GiocciRelayZenoh do
     GenServer.start_link(__MODULE__, state, name: String.to_atom(id_string))
     Logger.info("key_prefix/giocci/client_to_relay/" <> relay_name)
     ## subの開始
-    subscriber_loop_client2relay(state)
+    subscriber_loop_client_to_relay(state)
     {:ok, state}
   end
 
@@ -188,14 +188,14 @@ defmodule GiocciRelayZenoh do
   end
 
   ## subを永続化する関数
-  defp subscriber_loop_engine2relay(state) do
-    case Zenohex.Subscriber.recv_timeout(state.subscriber_engine2relay, 10_000) do
+  defp subscriber_loop_engine_to_relay(state) do
+    case Zenohex.Subscriber.recv_timeout(state.subscriber_engine_to_relay, 10_000) do
       {:ok, sample} ->
-        state.callback_engine2relay.(state, sample)
-        send(state.id, :loop_engine2relay)
+        state.callback_engine_to_relay.(state, sample)
+        send(state.id, :loop_engine_to_relay)
 
       {:error, :timeout} ->
-        send(state.id, :loop_engine2relay)
+        send(state.id, :loop_engine_to_relay)
 
       {:error, error} ->
         Logger.error(inspect(error))
@@ -206,14 +206,14 @@ defmodule GiocciRelayZenoh do
   end
 
   ## subを永続化する関数
-  defp subscriber_loop_client2relay(state) do
-    case Zenohex.Subscriber.recv_timeout(state.subscriber_client2relay, 10_000) do
+  defp subscriber_loop_client_to_relay(state) do
+    case Zenohex.Subscriber.recv_timeout(state.subscriber_client_to_relay, 10_000) do
       {:ok, sample} ->
-        state.callback_client2relay.(state, sample)
-        send(state.id, :loop_client2relay)
+        state.callback_client_to_relay.(state, sample)
+        send(state.id, :loop_client_to_relay)
 
       {:error, :timeout} ->
-        send(state.id, :loop_client2relay)
+        send(state.id, :loop_client_to_relay)
 
       {:error, error} ->
         Logger.error(inspect(error))

--- a/lib/giocci_relay_zenoh.ex
+++ b/lib/giocci_relay_zenoh.ex
@@ -14,67 +14,36 @@ defmodule GiocciRelayZenoh do
     最初に指定された数のEngineノードとのZenohコネクションを作成する（clientは一個想定
   """
   def setup_relay() do
+    create_clientsession(
+      Application.get_env(:giocci_relay_zenoh, :system_variables)[:client_node_name]
+    )
+
+    create_session(Application.get_env(:giocci_relay_zenoh, :system_variables)[:engine_node_name])
+  end
+
+  def start_link(engine_name) do
     relay_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:my_node_name]
-    client_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:client_node_name]
     ## RelayのZenohセッションを起動
     {:ok, session} = Zenohex.open()
-    ## pub,subそれぞれのキーをたてる
 
-    {:ok, subscriber} =
-      Zenohex.Session.declare_subscriber(
-        session,
-        "key_prefix/giocci/client_to_relay/" <> relay_name
-      )
-
-    id_string = relay_name <> "sub from client"
-    ## 状態として次の状態をもつ
-    state = %{
-      subscriber_client2relay: subscriber,
-      callback_client2relay: &callback_fromclient/2,
-      id: String.to_atom(id_string),
-      session: session
-    }
-
-    ## 上記の状態を保存する用のGenServerの起動
-    GenServer.start_link(__MODULE__, state, name: String.to_atom(id_string))
-    Logger.info("key_prefix/giocci/client_to_relay/" <> relay_name)
-    ## subの開始
-    subscriber_loop_client2relay(state)
-    {:ok, state}
-
-    {:ok, session} = Zenohex.open()
-    ## pub,subそれぞれのキーをたてる
-
-    {:ok, publisher} =
-      Zenohex.Session.declare_publisher(
-        session,
-        "key_prefix/giocci/relay_to_client/" <> client_name
-      )
-
-    id_string = client_name <> relay_name <> "pub"
-    ## 状態として次の状態をもつ
-    state = %{
-      publisher_relay2client: publisher,
-      id: String.to_atom(id_string),
-      session: session
-    }
-
-    ## 上記の状態を保存する用のGenServerの起動
-    GenServer.start_link(__MODULE__, state, name: String.to_atom(id_string))
-    ## subの開始
-    {:ok, state}
-
-    {:ok, session} = Zenohex.open()
     ## subのキーをたてる
     {:ok, subscriber} =
       Zenohex.Session.declare_subscriber(
         session,
-        "key_prefix/giocci/engine_to_relay/" <> relay_name
+        "key_prefix/giocci/engine_to_relay/" <> engine_name <> "/" <> relay_name
       )
 
-    id_string = relay_name <> "sub from engine"
+    ## pubキーをたてる
+    {:ok, publisher} =
+      Zenohex.Session.declare_publisher(
+        session,
+        "key_prefix/giocci/relay_to_engine/" <> relay_name <> "/" <> engine_name
+      )
+
+    id_string = relay_name <> engine_name
     ## 状態として次の状態をもつ
     state = %{
+      publisher_relay2engine: publisher,
       subscriber_engine2relay: subscriber,
       callback_engine2relay: &callback_fromengine/2,
       id: String.to_atom(id_string),
@@ -83,38 +52,9 @@ defmodule GiocciRelayZenoh do
 
     ## 上記の状態を保存する用のGenServerの起動
     GenServer.start_link(__MODULE__, state, name: String.to_atom(id_string))
+    Logger.info("key_prefix/giocci/relay_to_engine/" <> relay_name <> "/" <> engine_name)
     ## subの開始
     subscriber_loop_engine2relay(state)
-    {:ok, state}
-
-    create_session(Application.get_env(:giocci_relay_zenoh, :system_variables)[:engine_node_name])
-  end
-
-  def start_link(engine_name) do
-    relay_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:my_node_name]
-    client_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:client_node_name]
-    ## RelayのZenohセッションを起動
-    {:ok, session} = Zenohex.open()
-    ## pubキーをたてる
-
-    {:ok, publisher} =
-      Zenohex.Session.declare_publisher(
-        session,
-        "key_prefix/giocci/relay_to_engine/" <> engine_name
-      )
-
-    id_string = relay_name <> engine_name <> "pub"
-    ## 状態として次の状態をもつ
-    state = %{
-      publisher_relay2engine: publisher,
-      id: String.to_atom(id_string),
-      session: session
-    }
-
-    ## 上記の状態を保存する用のGenServerの起動
-    GenServer.start_link(__MODULE__, state, name: String.to_atom(id_string))
-    Logger.info("key_prefix/giocci/relay_to_engine/" <> engine_name)
-    ## subの開始
     {:ok, state}
   end
 
@@ -141,7 +81,7 @@ defmodule GiocciRelayZenoh do
         engine_name_tosend =
           Application.get_env(:giocci_relay_zenoh, :system_variables)[:engine_name_tosend]
 
-        id = (relay_name <> engine_name_tosend <> "pub") |> String.to_atom()
+        id = (relay_name <> engine_name_tosend) |> String.to_atom()
         ## publisherをセッションから作成しpublishする
         [publisher] =
           GenServer.call(id, :call_publisher_toengine)
@@ -153,7 +93,7 @@ defmodule GiocciRelayZenoh do
         engine_name_tosend =
           Application.get_env(:giocci_relay_zenoh, :system_variables)[:engine_name_tosend]
 
-        id = (relay_name <> engine_name_tosend <> "pub") |> String.to_atom()
+        id = (relay_name <> engine_name_tosend) |> String.to_atom()
         ## publisherをセッションから作成しpublishする
         [publisher] =
           GenServer.call(id, :call_publisher_toengine)
@@ -179,7 +119,7 @@ defmodule GiocciRelayZenoh do
     client_name_tosend =
       Application.get_env(:giocci_relay_zenoh, :system_variables)[:client_name_tosend]
 
-    id = (client_name_tosend <> relay_name <> "pub") |> String.to_atom()
+    id = (client_name_tosend <> relay_name) |> String.to_atom()
     ## publisherをセッションから作成しpublishする
     [publisher] =
       GenServer.call(id, :call_publisher_toclient)
@@ -207,6 +147,43 @@ defmodule GiocciRelayZenoh do
   def handle_info(:loop_client2relay, state) do
     subscriber_loop_client2relay(state)
     {:noreply, state}
+  end
+
+  defp create_clientsession(client_name) do
+    relay_name = Application.get_env(:giocci_relay_zenoh, :system_variables)[:my_node_name]
+    ## RelayのZenohセッションを起動
+    {:ok, session} = Zenohex.open()
+
+    ## pub,subそれぞれのキーをたてる
+
+    {:ok, subscriber} =
+      Zenohex.Session.declare_subscriber(
+        session,
+        "key_prefix/giocci/client_to_relay/" <> client_name <> "/" <> relay_name
+      )
+
+    {:ok, publisher} =
+      Zenohex.Session.declare_publisher(
+        session,
+        "key_prefix/giocci/relay_to_client/" <> relay_name <> "/" <> client_name
+      )
+
+    id_string = client_name <> relay_name
+    ## 状態として次の状態をもつ
+    state = %{
+      subscriber_client2relay: subscriber,
+      publisher_relay2client: publisher,
+      callback_client2relay: &callback_fromclient/2,
+      id: String.to_atom(id_string),
+      session: session
+    }
+
+    ## 上記の状態を保存する用のGenServerの起動
+    GenServer.start_link(__MODULE__, state, name: String.to_atom(id_string))
+    Logger.info("key_prefix/giocci/client_to_relay/" <> relay_name)
+    ## subの開始
+    subscriber_loop_client2relay(state)
+    {:ok, state}
   end
 
   defp create_session([]) do


### PR DESCRIPTION
キーネームのプレフィックス以外の部分を変更しました。
それに伴い、キーを作る部分でキーごとにセッションを分離しました。